### PR TITLE
beneficiary field name change

### DIFF
--- a/source/resources/collections/swagger.yaml
+++ b/source/resources/collections/swagger.yaml
@@ -1412,7 +1412,7 @@ definitions:
     - blockTransactionsHash
     - blockReceiptsHash
     - stateHash
-    - beneficiaryPublicKey
+    - beneficiary
     properties:
       signature:
         type: string
@@ -1438,7 +1438,7 @@ definitions:
         type: string
       stateHash:
         type: string
-      beneficiaryPublicKey:
+      beneficiary:
         type: string
   HeightDTO:
     type: object


### PR DESCRIPTION
from a discussion with @Vektrat, the block's `beneficiaryPublicKey` field was renamed to `beneficiary`.