### PR TITLE
Updated swagger with missing AccountDTO properties

### DIFF
--- a/source/resources/collections/openapi3.yaml
+++ b/source/resources/collections/openapi3.yaml
@@ -107,6 +107,7 @@ paths:
         description: Number of transactions to return for each request.
         schema:
           type: integer
+          format: int32
           minimum: 10
           maximum: 100
           default: 10
@@ -159,6 +160,7 @@ paths:
         description: Number of transactions to return for each request.
         schema:
           type: integer
+          format: int32
           minimum: 10
           maximum: 100
           default: 10
@@ -210,6 +212,7 @@ paths:
         description: Number of transactions to return for each request.
         schema:
           type: integer
+          format: int32
           minimum: 10
           maximum: 100
           default: 10
@@ -261,6 +264,7 @@ paths:
         description: Number of transactions to return for each request.
         schema:
           type: integer
+          format: int32
           minimum: 10
           maximum: 100
           default: 10
@@ -312,6 +316,7 @@ paths:
         description: Number of transactions to return for each request.
         schema:
           type: integer
+          format: int32
           minimum: 10
           maximum: 100
           default: 10
@@ -470,6 +475,7 @@ paths:
         required: true
         schema:
           type: integer
+          format: int32
           enum:
           - 25
           - 50
@@ -537,6 +543,7 @@ paths:
         description: Number of transactions to return for each request.
         schema:
           type: integer
+          format: int32
           minimum: 10
           maximum: 100
           default: 10
@@ -843,6 +850,7 @@ paths:
         description: Number of namespaces to return.
         schema:
           type: integer
+          format: int32
       - name: id
         in: query
         description: Namespace identifier to which namespace objects are returned.
@@ -873,6 +881,7 @@ paths:
         description: Number of namespaces to return.
         schema:
           type: integer
+          format: int32
       - name: id
         in: query
         description: Namespace identifier to which namespace objects are returned.
@@ -1192,6 +1201,7 @@ components:
     # Enumerations
     AliasActionEnum:
       type: integer
+      format: int32
       enum:
       - 0
       - 1
@@ -1202,6 +1212,7 @@ components:
       example: 0
     AliasTypeEnum:
       type: integer
+      format: int32
       enum:
       - 0
       - 1
@@ -1214,6 +1225,7 @@ components:
       example: 0
     AccountRestrictionTypeEnum:
       type: integer
+      format: int32
       example: 1
       enum:
       - 1
@@ -1236,6 +1248,7 @@ components:
         * 0xC1 (193 decimal) - Block outgoing transactions to a given address.
     AccountRestrictionModificationTypeEnum:
       type: integer
+      format: int32
       enum:
       - 0
       - 1
@@ -1246,6 +1259,7 @@ components:
       example: 0
     EntityTypeEnum:
       type: integer
+      format: int32
       enum:
       - 16716
       - 16705
@@ -1291,6 +1305,7 @@ components:
         * 0x8143 (33091 decimal) - Regular block.
     HashAlgorithmEnum:
       type: integer
+      format: int32
       enum:
       - 0
       - 1
@@ -1304,6 +1319,7 @@ components:
         * 3 (Op_Hash_256) - Proof is hashed twice with Sha-256 (bitcoin’s OP_HASH256).
     LinkActionEnum:
       type: integer
+      format: int32
       enum:
       - 0
       - 1
@@ -1313,6 +1329,7 @@ components:
         * 1 - Unlink.
     MessageTypeEnum:
       type: integer
+      format: int32
       enum:
       - 0
       description: |
@@ -1321,6 +1338,7 @@ components:
       example: 0
     MosaicPropertyIdEnum:
       type: integer
+      format: int32
       enum:
       - 0
       - 1
@@ -1333,6 +1351,7 @@ components:
       example: 0
     MosaicSupplyChangeDirectionEnum:
       type: integer
+      format: int32
       enum:
       - 0
       - 1
@@ -1343,6 +1362,7 @@ components:
       example: 0
     MosaicRestrictionTypeEnum:
       type: integer
+      format: int32
       enum:
       - 0
       - 1
@@ -1362,6 +1382,7 @@ components:
         * 6 (GE) - Allow if greater than or equal.
     MultisigModificationTypeEnum:
       type: integer
+      format: int32
       enum:
       - 0
       - 1
@@ -1372,6 +1393,7 @@ components:
       example: 0
     NamespaceTypeEnum:
       type: integer
+      format: int32
       enum:
       - 0
       - 1
@@ -1382,6 +1404,7 @@ components:
       example: 0
     ReceiptTypeEnum:
       type: integer
+      format: int32
       enum:
       - 4685
       - 4942
@@ -1417,6 +1440,7 @@ components:
         * 0xF243 (62019 decimal) - Mosaic_Alias_Resolution.
     NetworkTypeEnum:
       type: integer
+      format: int32
       description: |
         Version of the entity. The higher byte represents the network
         identifier:
@@ -1427,6 +1451,7 @@ components:
       example: 36867
     RolesTypeEnum:
       type: integer
+      format: int32
       enum:
       - 1
       - 2
@@ -1440,7 +1465,7 @@ components:
       type: array
       items:
         type: integer
-        format: int32
+        format: int64
       example:
       - lower
       - higher
@@ -1489,6 +1514,7 @@ components:
           $ref: "#/components/schemas/UInt64DTO"
         accountType:
           type: integer
+          format: int32
           enum:
             - 0
             - 1
@@ -1588,6 +1614,7 @@ components:
       properties:
         level:
           type: integer
+          format: int32
           description: Level of the multisig account.
           example: 0
         multisigEntries:
@@ -1621,11 +1648,13 @@ components:
           example: 9081FCCB41F8C8409A9B99E485E0E28D23BD6304EF7215E01A
         minApproval:
           type: integer
+          format: int32
           description: Number of signatures needed to approve a transaction.
           example: 2
         minRemoval:
           description: Number of signatures needed to remove a cosignatory.
           type: integer
+          format: int32
           example: 1
         cosignatories:
           type: array
@@ -1697,9 +1726,11 @@ components:
           $ref: "#/components/schemas/UInt64DTO"
         numTransactions:
           type: integer
+          format: int32
           example: 0
         numStatements:
           type: integer
+          format: int32
           example: 1
     EntityDTO:
       type: object
@@ -1753,13 +1784,14 @@ components:
             $ref: "#/components/schemas/UInt64DTO"
           feeMultiplier:
             type: integer
+            format: int32
             description: Fee multiplier applied to transactions contained in block.
             example: 0
           previousBlockHash:
             type: string
             description: Hash of the previous block.
             example:
-            - 0
+            - 0000000000000000000000000000000000000000000000000000000000000000
           blockTransactionsHash:
             type: string
             description: |
@@ -1822,14 +1854,17 @@ components:
       properties:
         numBlocks:
           type: integer
+          format: int64
           description: Number of blocks stored.
           example: 245053
         numTransactions:
           type: integer
+          format: int64
           description: Number of transactions stored.
           example: 58590
         numAccounts:
           type: integer
+          format: int64
           description: Number of accounts created.
           example: 177
     StatementsDTO:
@@ -1917,10 +1952,12 @@ components:
       properties:
         primaryId:
           type: integer
+          format: int32
           description: Transaction index within the block.
           example: 1
         secondaryId:
           type: integer
+          format: int32
           description: Transaction index inside within the aggregate transaction. If
             the transaction is not an inner transaction, then the secondary id
             is set to 0.
@@ -1933,6 +1970,7 @@ components:
       properties:
         version:
           type: integer
+          format: int32
           description: Version of the receipt.
         type:
           $ref: "#/components/schemas/ReceiptTypeEnum"
@@ -2075,6 +2113,7 @@ components:
           example: EFF9BC7472263D03EF6362B1F200FD3061BCD1BABE78F82119FB88811227CE85
         revision:
           type: integer
+          format: int32
           description: Number of definitions for the same mosaic.
           example: 1
         properties:
@@ -2117,6 +2156,7 @@ components:
           type: boolean
         index:
           type: integer
+          format: int32
     NamespaceInfoDTO:
       type: object
       required:
@@ -2154,6 +2194,7 @@ components:
           $ref: "#/components/schemas/UInt64DTO"
         depth:
           type: integer
+          format: int32
           description: Level of the namespace.
           example: 1
         level0:
@@ -2213,6 +2254,7 @@ components:
           type: string
         index:
           type: integer
+          format: int32
         id:
           type: string
     TransactionInfoDTO:
@@ -2257,6 +2299,7 @@ components:
           type: string
         index:
           type: integer
+          format: int32
         id:
           type: string
     EmbeddedTransactionInfoDTO:
@@ -2335,6 +2378,7 @@ components:
       properties:
         mosaicNonce:
           type: integer
+          format: int32
           description: Random nonce used to generate the mosaic id.
           example: 0
         mosaicId:
@@ -2421,6 +2465,7 @@ components:
       properties:
         minRemovalDelta:
           type: integer
+          format: int32
           description: |
             Number of signatures needed to remove a cosignatory. If we are
             modifying an existing multisig account, this indicates the relative
@@ -2428,6 +2473,7 @@ components:
           example: 1
         minApprovalDelta:
           type: integer
+          format: int32
           description: |
             Number of signatures needed to approve a transaction. If we are
             modifying an existing multisig account, this indicates the relative
@@ -2934,6 +2980,7 @@ components:
       properties:
         position:
           type: integer
+          format: uint32
           example: 1
         hash:
           type: string

--- a/source/resources/collections/openapi3.yaml
+++ b/source/resources/collections/openapi3.yaml
@@ -1457,23 +1457,6 @@ components:
           $ref: "#/components/schemas/AccountDTO"
     AccountMetaDTO:
       type: object
-      required:
-      - height
-      - hash
-      - merkleComponentHash
-      - index
-      - id
-      properties:
-        height:
-          $ref: "#/components/schemas/UInt64DTO"
-        hash:
-          type: string
-        merkleComponentHash:
-          type: string
-        index:
-          type: integer
-        id:
-          type: string
     AccountDTO:
       type: object
       required:
@@ -1481,6 +1464,9 @@ components:
       - addressHeight
       - publicKey
       - publicKeyHeight
+      - accountType
+      - linkedAccountKey
+      - activityBuckets
       - mosaics
       - importance
       - importanceHeight
@@ -1501,12 +1487,30 @@ components:
           example: AC1A6E1D8DE5B17D2C6B1293F1CAD3829EEACF38D09311BB3C8E5A880092DE26
         publicKeyHeight:
           $ref: "#/components/schemas/UInt64DTO"
+        accountType:
+          type: integer
+          enum:
+            - 0
+            - 1
+            - 2
+            - 3
+          description: |
+            * 0 - Unlinked.
+            * 1 - Balance-holding account that is linked to a remote harvester account.
+            * 2 - Remote harvester account that is linked to a balance-holding account.
+            * 3 - Remote harvester eligible account that is unlinked.
+        linkedAccountKey:
+          type: string
+        activityBuckets:
+          type: array
+          items:
+            type: object
         mosaics:
           type: array
           description: |
-            List of mosaics the account owns. The amount is represented in
+            Mosaic units owned. The amount is represented in
             absolute amount. Thus a balance of 123456789 for a mosaic with
-            divisibility 6 (absolute) means the account owns 123.456789 instead.
+            divisibility 6 (absolute) means the account owns 123.456789.
           items:
             $ref: "#/components/schemas/MosaicDTO"
         importance:

--- a/source/resources/collections/swagger2.yaml
+++ b/source/resources/collections/swagger2.yaml
@@ -1230,23 +1230,6 @@ definitions:
         $ref: "#/definitions/AccountDTO"
   AccountMetaDTO:
     type: object
-    required:
-      - height
-      - hash
-      - merkleComponentHash
-      - index
-      - id
-    properties:
-      height:
-        $ref: "#/definitions/UInt64DTO"
-      hash:
-        type: string
-      merkleComponentHash:
-        type: string
-      index:
-        type: integer
-      id:
-        type: string
   AccountDTO:
     type: object
     required:
@@ -1254,6 +1237,9 @@ definitions:
       - addressHeight
       - publicKey
       - publicKeyHeight
+      - accountType
+      - linkedAccountKey
+      - activityBuckets
       - mosaics
       - importance
       - importanceHeight
@@ -1274,12 +1260,30 @@ definitions:
         example: AC1A6E1D8DE5B17D2C6B1293F1CAD3829EEACF38D09311BB3C8E5A880092DE26
       publicKeyHeight:
         $ref: "#/definitions/UInt64DTO"
+      accountType:
+        type: integer
+        enum:
+          - 0
+          - 1
+          - 2
+          - 3
+        description: |
+          * 0 - Unlinked.
+          * 1 - Balance-holding account that is linked to a remote harvester account.
+          * 2 - Remote harvester account that is linked to a balance-holding account.
+          * 3 - Remote harvester eligible account that is unlinked.
+      linkedAccountKey:
+        type: string
+      activityBuckets:
+        type: array
+        items:
+          type: object
       mosaics:
         type: array
         description: |
-          List of mosaics the account owns. The amount is represented in
+          Mosaic units owned. The amount is represented in
           absolute amount. Thus a balance of 123456789 for a mosaic with
-          divisibility 6 (absolute) means the account owns 123.456789 instead.
+          divisibility 6 (absolute) means the account owns 123.456789.
         items:
           $ref: "#/definitions/MosaicDTO"
       importance:

--- a/source/resources/collections/swagger2.yaml
+++ b/source/resources/collections/swagger2.yaml
@@ -102,6 +102,7 @@ paths:
         - name: pageSize
           in: query
           type: integer
+          format: int32
           description: Number of transactions to return for each request.
           minimum: 10
           maximum: 100
@@ -150,6 +151,7 @@ paths:
         - name: pageSize
           in: query
           type: integer
+          format: int32
           description: Number of transactions to return for each request.
           minimum: 10
           maximum: 100
@@ -198,6 +200,7 @@ paths:
           in: query
           description: Number of transactions to return for each request.
           type: integer
+          format: int32
           minimum: 10
           maximum: 100
           default: 10
@@ -244,6 +247,7 @@ paths:
         - name: pageSize
           in: query
           type: integer
+          format: int32
           description: Number of transactions to return for each request.
           minimum: 10
           maximum: 100
@@ -291,6 +295,7 @@ paths:
         - name: pageSize
           in: query
           type: integer
+          format: int32
           description: Number of transactions to return for each request.
           minimum: 10
           maximum: 100
@@ -432,15 +437,16 @@ paths:
         - name: height
           in: path
           type: integer
+          format: int64
           description: Height of the block. If height -1 is not a multiple of the limit
             provided, the inferior closest multiple + 1 is used instead.
           required: true
-          format: int64
           minimum: 1
         - name: limit
           in: path
           description: Number of blocks to be returned.
           type: integer
+          format: int32
           required: true
           enum:
             - 25
@@ -470,9 +476,9 @@ paths:
         - name: height
           in: path
           type: integer
+          format: int64
           description: Height of the block.
           required: true
-          format: int64
           minimum: 1
       responses:
         "200":
@@ -496,13 +502,14 @@ paths:
         - name: height
           in: path
           type: integer
+          format: int64
           description: Height of the block.
           required: true
-          format: int64
           minimum: 1
         - name: pageSize
           in: query
           type: integer
+          format: int32
           description: Number of transactions to return for each request.
           minimum: 10
           maximum: 100
@@ -540,9 +547,9 @@ paths:
         - name: height
           in: path
           type: integer
+          format: int64
           description: Height of the block.
           required: true
-          format: int64
           minimum: 1
         - name: hash
           in: path
@@ -571,9 +578,9 @@ paths:
         - name: height
           in: path
           type: integer
+          format: int64
           description: Height of the block.
           required: true
-          format: int64
           minimum: 1
       responses:
         "200":
@@ -602,9 +609,9 @@ paths:
         - name: height
           in: path
           type: integer
+          format: int64
           description: Height of the block.
           required: true
-          format: int64
           minimum: 1
         - name: hash
           in: path
@@ -805,6 +812,7 @@ paths:
         - name: pageSize
           in: query
           type: integer
+          format: int32
           description: Number of namespaces to return.
         - name: id
           in: query
@@ -838,6 +846,7 @@ paths:
         - name: pageSize
           in: query
           type: integer
+          format: int32
           description: Number of namespaces to return.
         - name: id
           in: query
@@ -1132,6 +1141,7 @@ definitions:
   # Enumerations
   AccountRestrictionTypeEnum:
     type: integer
+    format: int32
     example: 1
     enum:
       - 1
@@ -1156,6 +1166,7 @@ definitions:
       * 0xC1 (193 decimal) - Block outgoing transactions to a given address.
   AliasTypeEnum:
     type: integer
+    format: int32
     enum:
       - 0
       - 1
@@ -1168,6 +1179,7 @@ definitions:
     example: 0
   MosaicPropertyIdEnum:
     type: integer
+    format: int32
     enum:
       - 0
       - 1
@@ -1180,6 +1192,7 @@ definitions:
     example: 0
   NamespaceTypeEnum:
     type: integer
+    format: int32
     enum:
       - 0
       - 1
@@ -1190,6 +1203,7 @@ definitions:
     example: 0
   NetworkTypeEnum:
     type: integer
+    format: int32
     description: |
       Version of the entity. The higher byte represents the network
       identifier:
@@ -1200,6 +1214,7 @@ definitions:
     example: 36867
   RolesTypeEnum:
     type: integer
+    format: int32
     enum:
       - 1
       - 2
@@ -1213,7 +1228,7 @@ definitions:
     type: array
     items:
       type: integer
-      format: int32
+      format: int64
     example:
       - lower
       - higher
@@ -1262,6 +1277,7 @@ definitions:
         $ref: "#/definitions/UInt64DTO"
       accountType:
         type: integer
+        format: int32
         enum:
           - 0
           - 1
@@ -1350,6 +1366,7 @@ definitions:
     properties:
       level:
         type: integer
+        format: int32
         description: Level of the multisig account.
         example: 0
       multisigEntries:
@@ -1383,11 +1400,13 @@ definitions:
         example: 9081FCCB41F8C8409A9B99E485E0E28D23BD6304EF7215E01A
       minApproval:
         type: integer
+        format: int32
         description: Number of signatures needed to approve a transaction.
         example: 2
       minRemoval:
         description: Number of signatures needed to remove a cosignatory.
         type: integer
+        format: int32
         example: 1
       cosignatories:
         type: array
@@ -1448,9 +1467,11 @@ definitions:
         $ref: "#/definitions/UInt64DTO"
       numTransactions:
         type: integer
+        format: int32
         example: 0
       numStatements:
         type: integer
+        format: int32
         example: 1
   BlockDTO:
     type: object
@@ -1484,6 +1505,7 @@ definitions:
         $ref: "#/definitions/NetworkTypeEnum"
       type:
         type: integer
+        format: int32
         description: |
           Type of the block:
           * 0x8043 (32835 decimal) - Nemesis block.
@@ -1496,6 +1518,7 @@ definitions:
         $ref: "#/definitions/UInt64DTO"
       feeMultiplier:
         type: integer
+        format: int32
         description: Fee multiplier applied to transactions contained in block.
         example: 0
       previousBlockHash:
@@ -1626,10 +1649,12 @@ definitions:
     properties:
       primaryId:
         type: integer
+        format: int32
         description: Transaction index within the block.
         example: 1
       secondaryId:
         type: integer
+        format: int32
         description: Transaction index inside within the aggregate transaction. If the transaction is not an inner transaction, then the secondary id is set to 0.
         example: 0
   # Diagnostic endpoints
@@ -1642,14 +1667,17 @@ definitions:
     properties:
       numBlocks:
         type: integer
+        format: int64
         description: Number of blocks stored.
         example: 245053
       numTransactions:
         type: integer
+        format: int64
         description: Number of transactions stored.
         example: 58590
       numAccounts:
         type: integer
+        format: int64
         description: Number of accounts created.
         example: 177
   ServerDTO:
@@ -1724,6 +1752,7 @@ definitions:
         example: EFF9BC7472263D03EF6362B1F200FD3061BCD1BABE78F82119FB88811227CE85
       revision:
         type: integer
+        format: int32
         description: Number of definitions for the same mosaic.
         example: 1
       properties:
@@ -1767,6 +1796,7 @@ definitions:
         type: boolean
       index:
         type: integer
+        format: int32
   NamespaceInfoDTO:
     type: object
     required:
@@ -1804,6 +1834,7 @@ definitions:
         $ref: "#/definitions/UInt64DTO"
       depth:
         type: integer
+        format: int32
         description: Level of the namespace.
         example: 1
       level0:
@@ -1863,6 +1894,7 @@ definitions:
         type: string
       index:
         type: integer
+        format: int32
       id:
         type: string
   TransactionInfoDTO:
@@ -2048,6 +2080,7 @@ definitions:
     properties:
       position:
         type: integer
+        format: int32
         example: 1
       hash:
         type: string


### PR DESCRIPTION
* Force format to all integers.
* Change Uint64 [int32,int32] to uint64.
* Add AccountDTO missing fields (accountType, linkedAccountKey, activityBuckets).